### PR TITLE
feat: Add About page

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function AboutPage() {
+  return (
+    <div className="container mx-auto py-8 px-4">
+      <h1 className="text-3xl font-bold mb-4">About Us</h1>
+      <p className="mb-4">
+        This is the Todo application. Our mission is to help you manage your tasks efficiently.
+      </p>
+      <p className="mb-4">
+        We believe in simplicity and productivity.
+      </p>
+      <Link href="/" className="text-blue-500 hover:underline">
+        Go back to Todos
+      </Link>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from 'next/link';
 import axios from "axios";
 import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -210,7 +211,12 @@ export default function page() {
     <div className="max-w-3xl mx-auto py-8 px-4">
       <div className="flex justify-between items-center mb-8">
         <h1 className="text-3xl font-bold">Todos</h1>
-        <ModeToggle />
+        <div className="flex items-center gap-4"> {/* Added a div to group ModeToggle and About link */}
+          <ModeToggle />
+          <Link href="/about" className="text-sm text-muted-foreground hover:text-primary transition-colors">
+            About
+          </Link>
+        </div>
       </div>
 
       <div className="flex gap-2 mb-8">


### PR DESCRIPTION
Added a new About page to the application at `/about`. This page provides basic information about the Todo application.

Also added a link to the new About page in the header of the main Todos page.